### PR TITLE
Improve v2 API

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -31,6 +31,16 @@ err := stacktrace.Errorf("some error: %w", originalErr)
 
 ## Extracting Call Stack Information
 
+To get a formatted string representation of call stack information from an error:
+
+```go
+// Get as a string.
+// This is equivalent to the result of calling `err.Error()`
+// if err doesn't conatin call stack information.
+// s is an empty string if err is nil.
+s := stacktrace.Format(err)
+```
+
 To extract call stack information from an error:
 
 ```go

--- a/v2/debuginfo.go
+++ b/v2/debuginfo.go
@@ -25,15 +25,18 @@ func GetDebugInfo(err error) DebugInfo {
 	if err == nil {
 		return DebugInfo{}
 	}
-	var frames []string
+	return DebugInfo{StackEntries: stackEntries(err), Detail: err.Error()}
+}
+
+func stackEntries(err error) []string {
 	if err := extract(err); err != nil {
-		frames = make([]string, 0, len(err.Callers))
+		entries := make([]string, 0, len(err.Callers))
 		walkCallersFrames(err.Callers, func(frame *runtime.Frame) {
-			frames = append(frames, frameString(frame))
+			entries = append(entries, frameString(frame))
 		})
+		return entries
 	}
-	detail := err.Error()
-	return DebugInfo{Detail: detail, StackEntries: frames}
+	return nil
 }
 
 // Format returns a formatted string representation of the DebugInfo.

--- a/v2/debuginfo.go
+++ b/v2/debuginfo.go
@@ -2,6 +2,7 @@ package stacktrace
 
 import (
 	"runtime"
+	"strings"
 )
 
 // DebugInfo represents debug information about an error.
@@ -33,4 +34,19 @@ func GetDebugInfo(err error) DebugInfo {
 	}
 	detail := err.Error()
 	return DebugInfo{Detail: detail, StackEntries: frames}
+}
+
+// Format returns a formatted string representation of the DebugInfo.
+//
+// The output consists of the Detail message followed by the stack trace entries,
+// each separated by a newline and a tab ("\n\t").
+func (info DebugInfo) Format() string {
+	n := len(info.StackEntries)
+	if n == 0 {
+		return info.Detail
+	}
+	return strings.Join(
+		append(append(make([]string, 0, 1+n), info.Detail), info.StackEntries...),
+		"\n\t",
+	)
 }

--- a/v2/debuginfo.go
+++ b/v2/debuginfo.go
@@ -18,7 +18,12 @@ type DebugInfo struct {
 // GetDebugInfo extracts debug information from an error.
 // It collects stack trace frames and formats them as strings, then returns
 // this information along with the detailed error message in a [DebugInfo] struct.
+//
+// It returns a zero value if err is nil.
 func GetDebugInfo(err error) DebugInfo {
+	if err == nil {
+		return DebugInfo{}
+	}
 	var frames []string
 	if err := extract(err); err != nil {
 		frames = make([]string, 0, len(err.Callers))

--- a/v2/debuginfo_test.go
+++ b/v2/debuginfo_test.go
@@ -38,3 +38,51 @@ func TestGetDebugInfo(t *testing.T) {
 		}
 	})
 }
+
+func TestDebugInfo_Format(t *testing.T) {
+	tests := []struct {
+		name string
+		info stacktrace.DebugInfo
+		want string
+	}{
+		{
+			name: "full",
+			info: stacktrace.DebugInfo{StackEntries: []string{"1", "2"}, Detail: "detail"},
+			want: "detail\n\t1\n\t2",
+		},
+		{
+			name: "stackentries",
+			info: stacktrace.DebugInfo{StackEntries: []string{"1", "2"}},
+			want: "\n\t1\n\t2",
+		},
+		{
+			name: "detail",
+			info: stacktrace.DebugInfo{Detail: "detail"},
+			want: "detail",
+		},
+		{
+			name: "zero",
+			info: stacktrace.DebugInfo{},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.info.Format()
+			if got != tt.want {
+				t.Errorf("got=%s want=%s", got, tt.want)
+			}
+		})
+	}
+}
+
+func ExampleDebugInfo_Format() {
+	err := stacktrace.Trace(os.Chdir("/no/such/dir"))
+	fmt.Println(stacktrace.Format(err))
+}
+
+func ExampleDebugInfo_Format_nil() {
+	err := stacktrace.Trace(nil)
+	fmt.Println(stacktrace.Format(err))
+	// Output:
+}

--- a/v2/error.go
+++ b/v2/error.go
@@ -38,23 +38,7 @@ func extract(err error) *Error {
 }
 
 func newErrorSkip(err error, skip int) error {
-	return NewError(err, callers(skip+1))
-}
-
-func callers(skip int) []uintptr {
-	skip += 2
-	const size = 8
-	var pc []uintptr
-	for {
-		x := make([]uintptr, size)
-		n := runtime.Callers(skip, x)
-		if n == 0 {
-			break
-		}
-		pc = append(pc, x[:n]...)
-		skip += n
-	}
-	return pc
+	return NewError(err, Callers(skip+1))
 }
 
 // Error returns a string representation of the custom error, including

--- a/v2/stacktrace.go
+++ b/v2/stacktrace.go
@@ -11,6 +11,7 @@ package stacktrace
 import (
 	"errors"
 	"fmt"
+	"runtime"
 )
 
 // New returns an error created with errors.New along with stack trace information in a concise way.
@@ -42,4 +43,18 @@ func New(text string) error {
 // stacktrace.Errorf is slightly more concise and efficient.
 func Errorf(format string, a ...any) error {
 	return withSkip(fmt.Errorf(format, a...), 1)
+}
+
+// Format returns a formatted string representation of the [DebugInfo] from err.
+//
+// If err is nil, it returns an empty string.
+// If err's chain doesn't contain any stack trace information, it returns err.Error().
+//
+// This is equivalent to:
+//
+//	stacktrace.GetDebugInfo(err).Format()
+//
+// See [DebugInfo.Format].
+func Format(err error) string {
+	return GetDebugInfo(err).Format()
 }

--- a/v2/stacktrace.go
+++ b/v2/stacktrace.go
@@ -58,3 +58,27 @@ func Errorf(format string, a ...any) error {
 func Format(err error) string {
 	return GetDebugInfo(err).Format()
 }
+
+// Callers returns the program counters (PCs) of function invocations on the
+// calling goroutine's stack, skipping the specified number of stack frames.
+//
+// The skip parameter determines how many initial stack frames to omit from the
+// result. A skip value of 0 starts from the caller of Callers itself.
+//
+// The returned slice contains the collected program counters, which can be
+// further processed using runtime.CallersFrames to obtain function details.
+func Callers(skip int) []uintptr {
+	skip += 2
+	const size = 8
+	var pc []uintptr
+	for {
+		x := make([]uintptr, size)
+		n := runtime.Callers(skip, x)
+		if n == 0 {
+			break
+		}
+		pc = append(pc, x[:n]...)
+		skip += n
+	}
+	return pc
+}

--- a/v2/stacktrace_go123.go
+++ b/v2/stacktrace_go123.go
@@ -1,0 +1,27 @@
+//go:build go1.23
+
+package stacktrace
+
+import (
+	"iter"
+	"runtime"
+)
+
+// CallersFrames returns an iterator sequence of *[runtime.Frame] based on the given
+// slice of program counters (PCs). It yields stack frames one by one, stopping
+// if the iterator function returns false, if there are no more frames, or if
+// the function name is "main.main".
+//
+// The function utilizes runtime.CallersFrames to traverse the stack trace
+// and provides each frame through the yield function.
+func CallersFrames(callers []uintptr) iter.Seq[*runtime.Frame] {
+	return func(yield func(*runtime.Frame) bool) {
+		frames := runtime.CallersFrames(callers)
+		for {
+			frame, more := frames.Next()
+			if !yield(&frame) || !more {
+				break
+			}
+		}
+	}
+}

--- a/v2/stacktrace_go123_test.go
+++ b/v2/stacktrace_go123_test.go
@@ -1,0 +1,48 @@
+//go:build go1.23
+
+package stacktrace_test
+
+import (
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/goaux/stacktrace/v2"
+)
+
+func TestCallersFrames(t *testing.T) {
+	f1 := func() []uintptr { return stacktrace.Callers(0) }
+	f2 := func() []uintptr { return f1() }
+	f3 := func() []uintptr { return f2() }
+	callers := f3()
+
+	list := make([]string, 0, len(callers))
+	for frame := range stacktrace.CallersFrames(callers) {
+		list = append(list, funcnameOf(t, frame.PC))
+	}
+
+	if got, want := len(list), len(callers); got != want {
+		t.Errorf("len(list)=%d must be len(callers)=%d", got, want)
+	}
+
+	want := stacktrace.GetDebugInfo(stacktrace.NewError(nil, callers)).StackEntries
+	for i, s := range want {
+		want[i] = strings.Fields(s)[1]
+		if j := strings.Index(list[i], want[i]); j != -1 {
+			list[i] = list[i][j:]
+		}
+	}
+	if !slices.Equal(list, want) {
+		t.Errorf("list must be equal to callers; list=%v callers=%v", list, callers)
+	}
+}
+
+func funcnameOf(t *testing.T, pc uintptr) string {
+	t.Helper()
+	f := runtime.FuncForPC(pc)
+	if f == nil {
+		t.Fatal("runtime.FuncForPC(pc) must not return nil")
+	}
+	return f.Name()
+}


### PR DESCRIPTION
Improvements:

- Add `Format` and `DebugInfo.Format`
- Export `Callers`
- Add `CallersFrames` (go1.23 or later)