### PR TITLE
Rename functions to Trace2, Trace3 and Trace4

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -74,11 +74,11 @@ For example, the info contains information like below:
 
 ```
 {
+  "detail": "chdir /no/such/dir: no such file or directory (run.go:10 main.run)",
   "stack_entries": [
     "example.com/hello/run.go:10 main.run",
     "example.com/hello/main.go:11 main.main"
-  ],
-  "detail": "chdir /no/such/dir: no such file or directory (run.go:10 main.run)"
+  ]
 }
 ```
 

--- a/v2/README.md
+++ b/v2/README.md
@@ -15,15 +15,20 @@ Package stacktrace provides utilities for capturing and inspecting stack traces 
 
 ### Trace
 
-The most basic way to create an error with a stack trace is to use the `Trace` function:
+The most basic way to create an error with a stack trace is to use the [Trace][] function:
 
 ```go
 err := stacktrace.Trace(os.Chdir(target))
 ```
 
-There are `Trace2`, `Trace3`, and `Trace4`:
-These are overloads of `Trace` that return the given values unchanged if err is nil.
+There are [Trace2][], [Trace3][], and [Trace4][]:
+These are overloads of [Trace][] that return the given values unchanged if err is nil.
 If err is not nil, it wraps err with stack trace information before returning.
+
+[Trace]: https://pkg.go.dev/github.com/goaux/stacktrace/v2#Trace
+[Trace2]: https://pkg.go.dev/github.com/goaux/stacktrace/v2#Trace2
+[Trace3]: https://pkg.go.dev/github.com/goaux/stacktrace/v3#Trace3
+[Trace4]: https://pkg.go.dev/github.com/goaux/stacktrace/v4#Trace4
 
 ```go
 file, err := stacktrace.Trace2(os.Open(file))
@@ -31,12 +36,17 @@ file, err := stacktrace.Trace2(os.Open(file))
 
 ### New and Errorf
 
-For convenience, you can use `New` and `Errorf` as drop-in replacements for `errors.New` and `fmt.Errorf`:
+For convenience, you can use [New][] and [Errorf][] as drop-in replacements for [errors.New][] and [fmt.Errorf][]:
 
 ```go
 err := stacktrace.New("some error")
 err := stacktrace.Errorf("some error: %w", originalErr)
 ```
+
+[New]: https://pkg.go.dev/github.com/goaux/stacktrace/v2#New
+[Errorf]: https://pkg.go.dev/github.com/goaux/stacktrace/v2#Errorf
+[errors.New]: https://pkg.go.dev/errors#New
+[fmt.Errorf]: https://pkg.go.dev/fmt#Errorf
 
 ## Extracting Stack Trace Information
 
@@ -52,13 +62,16 @@ To get a formatted string representation of stack trace information from an erro
 s := stacktrace.Format(err)
 ```
 
+Use [Format][].
 For example, the `s` contains multiline string like below:
 
-```
+```text
 chdir /no/such/dir: no such file or directory (run.go:10 main.run)
         example.com/hello/run.go:10 main.run
         example.com/hello/main.go:11 main.main
 ```
+
+[Format]: https://pkg.go.dev/github.com/goaux/stacktrace/v2#Format
 
 ### As a DebugInfo
 
@@ -73,7 +86,7 @@ The [DebugInfo](https://pkg.go.dev/github.com/goaux/stacktrace/v2#DebugInfo) typ
 
 For example, the info contains information like below:
 
-```
+```json
 {
   "detail": "chdir /no/such/dir: no such file or directory (run.go:10 main.run)",
   "stack_entries": [
@@ -85,7 +98,21 @@ For example, the info contains information like below:
 
 ### Other ways
 
-Alternatively, you can use `errors.As` to extract the `Error` instance from an error chain.
+Alternatively, you can use [errors.As][] to extract the [Error][] instance from an error chain.
+[CallersFrames][] is available in Go 1.23 or later.
+
+[errors.As]: https://pkg.go.dev/errors#As
+[Error]: https://pkg.go.dev/github.com/goaux/stacktrace/v2#Error
+[CallersFrames]: https://pkg.go.dev/github.com/goaux/stacktrace/v2#CallersFrames
+
+```go
+var info *stacktrace.Error
+if errors.As(err, &info) {
+	for frame := range stacktrace.CallersFrames(info.Callers) {
+		_, _ = frame.File, frame.Line
+	}
+}
+```
 
 ## Performance Considerations
 

--- a/v2/README.md
+++ b/v2/README.md
@@ -1,15 +1,15 @@
 # stacktrace/v2
 
-Package stacktrace provides utilities for capturing and inspecting call stacks associated with errors.
+Package stacktrace provides utilities for capturing and inspecting stack traces associated with errors.
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/goaux/stacktrace/v2.svg)](https://pkg.go.dev/github.com/goaux/stacktrace/v2)
 [![Go Report Card](https://goreportcard.com/badge/github.com/goaux/stacktrace/v2)](https://goreportcard.com/report/github.com/goaux/stacktrace/v2)
 
 ## Features
 
-- Wraps errors with a single call stack
-  - Typically, a single error chain contains at most one call stack
-- Extracts the call stack from an error
+- Wraps errors with a single stack trace
+  - Typically, a single error chain contains at most one stack trace
+- Extracts the stack trace from an error
 
 ## Usage
 
@@ -21,8 +21,9 @@ The most basic way to create an error with a stack trace is to use the `Trace` f
 err := stacktrace.Trace(os.Chdir(target))
 ```
 
-There are overloads of `Trace` that return the original values along with the error.
-These are `Trace2`, `Trace3`, and `Trace4`:
+There are `Trace2`, `Trace3`, and `Trace4`:
+These are overloads of `Trace` that return the given values unchanged if err is nil.
+If err is not nil, it wraps err with stack trace information before returning.
 
 ```go
 file, err := stacktrace.Trace2(os.Open(file))
@@ -37,16 +38,16 @@ err := stacktrace.New("some error")
 err := stacktrace.Errorf("some error: %w", originalErr)
 ```
 
-## Extracting Call Stack Information
+## Extracting Stack Trace Information
 
 ### As a string
 
-To get a formatted string representation of call stack information from an error:
+To get a formatted string representation of stack trace information from an error:
 
 ```go
 // Get as a string.
 // This is equivalent to calling `err.Error()`
-// if `err` does not contain call stack information.
+// if `err` does not contain stack trace information.
 // `s` is an empty string if `err` is nil.
 s := stacktrace.Format(err)
 ```
@@ -61,7 +62,7 @@ chdir /no/such/dir: no such file or directory (run.go:10 main.run)
 
 ### As a DebugInfo
 
-To extract call stack information from an error:
+To extract stack trace information from an error:
 
 ```go
 // Get as a DebugInfo instance

--- a/v2/README.md
+++ b/v2/README.md
@@ -2,6 +2,9 @@
 
 Package stacktrace provides utilities for capturing and inspecting call stacks associated with errors.
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/goaux/stacktrace/v2.svg)](https://pkg.go.dev/github.com/goaux/stacktrace/v2)
+[![Go Report Card](https://goreportcard.com/badge/github.com/goaux/stacktrace/v2)](https://goreportcard.com/report/github.com/goaux/stacktrace/v2)
+
 ## Features
 
 - Wraps errors with a single call stack

--- a/v2/README.md
+++ b/v2/README.md
@@ -19,10 +19,10 @@ err := stacktrace.Trace(os.Chdir(target))
 ```
 
 There are overloads of `Trace` that return the original values along with the error.
-These are `Trace1`, `Trace2`, and `Trace3`:
+These are `Trace2`, `Trace3`, and `Trace4`:
 
 ```go
-file, err := stacktrace.Trace1(os.Open(file))
+file, err := stacktrace.Trace2(os.Open(file))
 ```
 
 For convenience, you can use `New` and `Errorf` as drop-in replacements for `errors.New` and `fmt.Errorf`:

--- a/v2/README.md
+++ b/v2/README.md
@@ -8,9 +8,12 @@ Package stacktrace provides utilities for capturing and inspecting call stacks a
 ## Features
 
 - Wraps errors with a single call stack
+  - Typically, a single error chain contains at most one call stack
 - Extracts the call stack from an error
 
 ## Usage
+
+### Trace
 
 The most basic way to create an error with a stack trace is to use the `Trace` function:
 
@@ -25,6 +28,8 @@ These are `Trace2`, `Trace3`, and `Trace4`:
 file, err := stacktrace.Trace2(os.Open(file))
 ```
 
+### New and Errorf
+
 For convenience, you can use `New` and `Errorf` as drop-in replacements for `errors.New` and `fmt.Errorf`:
 
 ```go
@@ -33,6 +38,8 @@ err := stacktrace.Errorf("some error: %w", originalErr)
 ```
 
 ## Extracting Call Stack Information
+
+### As a string
 
 To get a formatted string representation of call stack information from an error:
 
@@ -44,12 +51,44 @@ To get a formatted string representation of call stack information from an error
 s := stacktrace.Format(err)
 ```
 
+For example, the `s` contains multiline string like below:
+
+```
+chdir /no/such/dir: no such file or directory (debuginfo_test.go:80 ExampleDebugInfo_Format)
+        github.com/goaux/stacktrace/v2/debuginfo_test.go:80 ExampleDebugInfo_Format
+        testing/run_example.go:63 testing.runExample
+        testing/example.go:41 testing.runExamples
+        testing/testing.go:2144 testing.(*M).Run
+        _testmain.go:73 main.main
+```
+
+### As a DebugInfo
+
 To extract call stack information from an error:
 
 ```go
 // Get as a DebugInfo instance
 info := stacktrace.GetDebugInfo(err)
 ```
+
+The [DebugInfo](https://pkg.go.dev/github.com/goaux/stacktrace/v2#DebugInfo) type is compatible with [google.golang.org/genproto/googleapis/rpc/errdetails.DebugInfo](https://pkg.go.dev/google.golang.org/genproto/googleapis/rpc/errdetails#DebugInfo).
+
+For example, the info contains information like below:
+
+```
+{
+  "stack_entries": [
+    "github.com/goaux/stacktrace/v2/debuginfo_test.go:81 ExampleDebugInfo_Format",
+    "testing/run_example.go:63 testing.runExample",
+    "testing/example.go:41 testing.runExamples",
+    "testing/testing.go:2144 testing.(*M).Run",
+    "_testmain.go:73 main.main"
+  ],
+  "detail": "chdir /no/such/dir: no such file or directory (debuginfo_test.go:81 ExampleDebugInfo_Format)"
+}
+```
+
+### Other ways
 
 Alternatively, you can use `errors.As` to extract the `Error` instance from an error chain.
 

--- a/v2/README.md
+++ b/v2/README.md
@@ -54,12 +54,9 @@ s := stacktrace.Format(err)
 For example, the `s` contains multiline string like below:
 
 ```
-chdir /no/such/dir: no such file or directory (debuginfo_test.go:80 ExampleDebugInfo_Format)
-        github.com/goaux/stacktrace/v2/debuginfo_test.go:80 ExampleDebugInfo_Format
-        testing/run_example.go:63 testing.runExample
-        testing/example.go:41 testing.runExamples
-        testing/testing.go:2144 testing.(*M).Run
-        _testmain.go:73 main.main
+chdir /no/such/dir: no such file or directory (run.go:10 main.run)
+        example.com/hello/run.go:10 main.run
+        example.com/hello/main.go:11 main.main
 ```
 
 ### As a DebugInfo
@@ -78,13 +75,10 @@ For example, the info contains information like below:
 ```
 {
   "stack_entries": [
-    "github.com/goaux/stacktrace/v2/debuginfo_test.go:81 ExampleDebugInfo_Format",
-    "testing/run_example.go:63 testing.runExample",
-    "testing/example.go:41 testing.runExamples",
-    "testing/testing.go:2144 testing.(*M).Run",
-    "_testmain.go:73 main.main"
+    "example.com/hello/run.go:10 main.run",
+    "example.com/hello/main.go:11 main.main"
   ],
-  "detail": "chdir /no/such/dir: no such file or directory (debuginfo_test.go:81 ExampleDebugInfo_Format)"
+  "detail": "chdir /no/such/dir: no such file or directory (run.go:10 main.run)"
 }
 ```
 

--- a/v2/debuginfo.go
+++ b/v2/debuginfo.go
@@ -9,11 +9,11 @@ import (
 //
 // This struct is compatible with [google.golang.org/genproto/googleapis/rpc/errdetails.DebugInfo].
 type DebugInfo struct {
-	// StackEntries contains a list of stack trace entries related to the error.
-	StackEntries []string `json:"stack_entries,omitempty"`
-
 	// Detail provides a detailed error message.
 	Detail string `json:"detail,omitempty"`
+
+	// StackEntries contains a list of stack trace entries related to the error.
+	StackEntries []string `json:"stack_entries,omitempty"`
 }
 
 // GetDebugInfo extracts debug information from an error.

--- a/v2/debuginfo_go121_test.go
+++ b/v2/debuginfo_go121_test.go
@@ -23,7 +23,7 @@ func TestDebugInfo_slog(t *testing.T) {
 		txt := buf.String()
 		i := strings.Index(txt, ` err="{`)
 		got := txt[i:]
-		want := ` err="{StackEntries:[entry#1 entry#2] Detail:debuginfo-detail}"` + "\n"
+		want := ` err="{Detail:debuginfo-detail StackEntries:[entry#1 entry#2]}"` + "\n"
 		if got != want {
 			t.Errorf("got=%q want=%q", got, want)
 		}
@@ -35,7 +35,7 @@ func TestDebugInfo_slog(t *testing.T) {
 		txt := buf.String()
 		i := strings.Index(txt, `"err":{`)
 		got := txt[i:]
-		want := `"err":{"stack_entries":["entry#1","entry#2"],"detail":"debuginfo-detail"}}` + "\n"
+		want := `"err":{"detail":"debuginfo-detail","stack_entries":["entry#1","entry#2"]}}` + "\n"
 		if got != want {
 			t.Errorf("got=%q want=%q", got, want)
 		}

--- a/v2/error.go
+++ b/v2/error.go
@@ -13,7 +13,7 @@ import (
 // It is recommended to use the following functions to create an instance of Error:
 //
 //   - [Trace]: Adds a call stack indicating where [Trace] was executed to the given error and returns it.
-//   - [Trace1], [Trace2], [Trace3]: Variants of [Trace] that accept multiple
+//   - [Trace2], [Trace3], [Trace4]: Variants of [Trace] that accept multiple
 //     arbitrary arguments along with an error and return them.
 //     The trailing number represents the number of additional arguments other than the error.
 //   - [Errorf]: A function that wraps `fmt.Errorf` with `Trace`.
@@ -21,7 +21,7 @@ import (
 //
 // If `nil` is passed to [Trace] and its variants, they return `nil` as an error.
 //
-// [Trace], [Trace1], [Trace2], [Trace3], and [Errorf] do not add a new call
+// [Trace], [Trace2], [Trace3], [Trace4], and [Errorf] do not add a new call
 // stack if the given error already has one, meaning that if an `Error`
 // instance is already present in the error chain, the original error is
 // returned as-is.

--- a/v2/stacktrace.go
+++ b/v2/stacktrace.go
@@ -69,15 +69,16 @@ func Format(err error) string {
 // further processed using runtime.CallersFrames to obtain function details.
 func Callers(skip int) []uintptr {
 	skip += 2
-	const size = 8
+	const size = 16
 	var pc []uintptr
 	for {
 		x := make([]uintptr, size)
 		n := runtime.Callers(skip, x)
-		if n == 0 {
+		if n != len(x) {
+			pc = append(pc, x[:n]...)
 			break
 		}
-		pc = append(pc, x[:n]...)
+		pc = append(pc, x...)
 		skip += n
 	}
 	return pc

--- a/v2/stacktrace_test.go
+++ b/v2/stacktrace_test.go
@@ -16,7 +16,7 @@ func Example() {
 		fmt.Printf("%d stack entries included.", len(info.StackEntries))
 		panic(stacktrace.GetDebugInfo(err))
 	}
-	if file, err := stacktrace.Trace1(os.Open("./no/such/file")); err != nil {
+	if file, err := stacktrace.Trace2(os.Open("./no/such/file")); err != nil {
 		fmt.Println("err.Error():", err.Error())
 		info := stacktrace.GetDebugInfo(err)
 		fmt.Println("info.Detail:", info.Detail)

--- a/v2/trace.go
+++ b/v2/trace.go
@@ -6,24 +6,30 @@ func Trace(err error) error {
 	return traceSkip(err, 1)
 }
 
-// Trace1 takes a value of any type and an error, returning the original value
-// and nil if the error is not nil, or the error along with stack frame
-// information.
-func Trace1[T0 any](v0 T0, err error) (T0, error) {
+// Trace2 returns the given values unchanged if err is nil.
+// If err is not nil, it wraps err with stack trace information before returning.
+//
+// The function name "Trace2" indicates that it takes two arguments
+// (a value of any type and an error) and returns two values.
+func Trace2[T0 any](v0 T0, err error) (T0, error) {
 	return v0, traceSkip(err, 1)
 }
 
-// Trace2 takes two values of any type and an error, returning the original
-// values and nil if the error is not nil, or the error along with stack frame
-// information.
-func Trace2[T0, T1 any](v0 T0, v1 T1, err error) (T0, T1, error) {
+// Trace3 returns the given values unchanged if err is nil.
+// If err is not nil, it wraps err with stack trace information before returning.
+//
+// The function name "Trace3" indicates that it takes three arguments
+// (two values of any type and an error) and returns three values.
+func Trace3[T0, T1 any](v0 T0, v1 T1, err error) (T0, T1, error) {
 	return v0, v1, traceSkip(err, 1)
 }
 
-// Trace3 takes three values of any type and an error, returning the original
-// values and nil if the error is not nil, or the error along with stack frame
-// information.
-func Trace3[T0, T1, T2 any](v0 T0, v1 T1, v2 T2, err error) (T0, T1, T2, error) {
+// Trace4 returns the given values unchanged if err is nil.
+// If err is not nil, it wraps err with stack trace information before returning.
+//
+// The function name "Trace4" indicates that it takes four arguments
+// (three values of any type and an error) and returns four values.
+func Trace4[T0, T1, T2 any](v0 T0, v1 T1, v2 T2, err error) (T0, T1, T2, error) {
 	return v0, v1, v2, traceSkip(err, 1)
 }
 

--- a/v2/trace_test.go
+++ b/v2/trace_test.go
@@ -29,10 +29,10 @@ func TestTrace(t *testing.T) {
 	})
 }
 
-func TestTrace1(t *testing.T) {
+func TestTrace2(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		ok := func() (int, error) { return 42, nil }
-		i, err := stacktrace.Trace1(ok())
+		i, err := stacktrace.Trace2(ok())
 		if err != nil {
 			t.Error("err must be nil")
 		}
@@ -41,20 +41,20 @@ func TestTrace1(t *testing.T) {
 		}
 	})
 	t.Run("StackEntries[0]", func(t *testing.T) {
-		_, err := stacktrace.Trace1(os.ReadDir("/no/such/dir"))
+		_, err := stacktrace.Trace2(os.ReadDir("/no/such/dir"))
 		_, file, line, _ := runtime.Caller(0)
 		debugInfo := stacktrace.GetDebugInfo(err)
-		want := fmt.Sprintf("%s:%d TestTrace1.func2", file, line-1)
+		want := fmt.Sprintf("%s:%d TestTrace2.func2", file, line-1)
 		if got := debugInfo.StackEntries[0]; got != want {
 			t.Errorf("want=%q got=%q", want, got)
 		}
 	})
 }
 
-func TestTrace2(t *testing.T) {
+func TestTrace3(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		ok := func() (int, string, error) { return 42, "42", nil }
-		i, s, err := stacktrace.Trace2(ok())
+		i, s, err := stacktrace.Trace3(ok())
 		if err != nil {
 			t.Error("err must be nil")
 		}
@@ -70,20 +70,20 @@ func TestTrace2(t *testing.T) {
 			err = errors.New("TESTING")
 			return
 		}
-		_, _, err := stacktrace.Trace2(fn())
+		_, _, err := stacktrace.Trace3(fn())
 		_, file, line, _ := runtime.Caller(0)
 		debugInfo := stacktrace.GetDebugInfo(err)
-		want := fmt.Sprintf("%s:%d TestTrace2.func2", file, line-1)
+		want := fmt.Sprintf("%s:%d TestTrace3.func2", file, line-1)
 		if got := debugInfo.StackEntries[0]; got != want {
 			t.Errorf("want=%q got=%q", want, got)
 		}
 	})
 }
 
-func TestTrace3(t *testing.T) {
+func TestTrace4(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		ok := func() (int, string, float64, error) { return 42, "42", 42.42, nil }
-		i, s, f, err := stacktrace.Trace3(ok())
+		i, s, f, err := stacktrace.Trace4(ok())
 		if err != nil {
 			t.Error("err must be nil")
 		}
@@ -102,10 +102,10 @@ func TestTrace3(t *testing.T) {
 			err = errors.New("TESTING")
 			return
 		}
-		_, _, _, err := stacktrace.Trace3(fn())
+		_, _, _, err := stacktrace.Trace4(fn())
 		_, file, line, _ := runtime.Caller(0)
 		debugInfo := stacktrace.GetDebugInfo(err)
-		want := fmt.Sprintf("%s:%d TestTrace3.func2", file, line-1)
+		want := fmt.Sprintf("%s:%d TestTrace4.func2", file, line-1)
 		if got := debugInfo.StackEntries[0]; got != want {
 			t.Errorf("want=%q got=%q", want, got)
 		}


### PR DESCRIPTION
Updated function names to better reflect their purpose and improve consistency.
This change is breaking as it modifies existing function names.