### PR TITLE
Removed use of slices.Equal as the slices package is not available in Go 1.20

### DIFF
--- a/v2/equal_go121_test.go
+++ b/v2/equal_go121_test.go
@@ -1,0 +1,10 @@
+//go:build go1.21
+
+package stacktrace_test
+
+import "slices"
+
+// equal returns the result of calling `slices.Equal(s1, s2)`.
+func equal(s1, s2 []uintptr) bool {
+	return slices.Equal(s1, s2)
+}

--- a/v2/equal_test.go
+++ b/v2/equal_test.go
@@ -1,0 +1,20 @@
+//go:build !go1.21
+
+package stacktrace_test
+
+// equal returns true if `s1` and `s2` are identical.
+//
+// In Go 1.20, [slices.Equal] was not available, so this custom implementation
+// was created. Once support for Go versions 1.21 or later is ensured, it is
+// recommended to use [slices.Equal` and remove this function.
+func equal(s1, s2 []uintptr) bool {
+	if len(s1) != len(s2) {
+		return false
+	}
+	for i := range s1 {
+		if s1[i] != s2[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/v2/error_test.go
+++ b/v2/error_test.go
@@ -37,20 +37,3 @@ func TestError(t *testing.T) {
 		}
 	})
 }
-
-// equal returns true if `s1` and `s2` are identical.
-//
-// In Go 1.20, [slices.Equal] was not available, so this custom implementation
-// was created. Once support for Go versions 1.21 or later is ensured, it is
-// recommended to use [slices.Equal` and remove this function.
-func equal(s1, s2 []uintptr) bool {
-	if len(s1) != len(s2) {
-		return false
-	}
-	for i := range s1 {
-		if s1[i] != s2[i] {
-			return false
-		}
-	}
-	return true
-}

--- a/v2/error_test.go
+++ b/v2/error_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"slices"
 	"testing"
 
 	"github.com/goaux/stacktrace/v2"
@@ -32,9 +31,26 @@ func TestError(t *testing.T) {
 		if v, ok := err.(stacktrace.StackTracer); ok {
 			got := v.StackTrace()
 			want := []uintptr{1, 2, 3}
-			if !slices.Equal(got, want) {
+			if !equal(got, want) {
 				t.Errorf("got=%v want=%v", got, want)
 			}
 		}
 	})
+}
+
+// equal returns true if `s1` and `s2` are identical.
+//
+// In Go 1.20, [slices.Equal] was not available, so this custom implementation
+// was created. Once support for Go versions 1.21 or later is ensured, it is
+// recommended to use [slices.Equal` and remove this function.
+func equal(s1, s2 []uintptr) bool {
+	if len(s1) != len(s2) {
+		return false
+	}
+	for i := range s1 {
+		if s1[i] != s2[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Removed use of slices.Equal for Go 1.20; will use it for Go 1.21 and above

Closes #12 