### PR TITLE
Fix: Handle empty caller slice in CallersFrames

### DIFF
--- a/v2/stacktrace_go123.go
+++ b/v2/stacktrace_go123.go
@@ -15,6 +15,9 @@ import (
 // and provides each frame through the yield function.
 func CallersFrames(callers []uintptr) iter.Seq[*runtime.Frame] {
 	return func(yield func(*runtime.Frame) bool) {
+		if len(callers) == 0 {
+			return
+		}
 		frames := runtime.CallersFrames(callers)
 		for {
 			frame, more := frames.Next()

--- a/v2/stacktrace_go123_test.go
+++ b/v2/stacktrace_go123_test.go
@@ -36,6 +36,16 @@ func TestCallersFrames(t *testing.T) {
 	if !slices.Equal(list, want) {
 		t.Errorf("list must be equal to callers; list=%v callers=%v", list, callers)
 	}
+
+	t.Run("nil", func(t *testing.T) {
+		n := 0
+		for range stacktrace.CallersFrames(nil) {
+			n++
+		}
+		if n != 0 {
+			t.Errorf("n must be 0, but %d", n)
+		}
+	})
 }
 
 func funcnameOf(t *testing.T, pc uintptr) string {


### PR DESCRIPTION
The `CallerFrames` function now returns an iterator that immediately returns when given an empty caller slice.
This prevents unnecessary iteration and potential issues when no stack frames are available.
A test case has been added to verify this behavior.

Closes #29 