### PR TITLE
Add: Implement CallersLimit function

### DIFF
--- a/v2/callers.go
+++ b/v2/callers.go
@@ -26,3 +26,29 @@ func Callers(skip int) []uintptr {
 	}
 	return pc
 }
+
+// CallersLimit returns the program counters (PCs) of function invocations on the
+// calling goroutine's stack, skipping the specified number of stack frames and
+// limiting the number of returned frames.
+//
+// The skip parameter determines how many initial stack frames to omit from the
+// result. A skip value of 0 starts from the caller of CallersLimit itself.
+//
+// The limit parameter specifies the maximum number of stack frames to return.
+// If limit is 0, an empty slice is returned. If limit is negative, all available
+// stack frames after skipping are returned (equivalent to calling Callers with
+// skip + 1).
+//
+// The returned slice contains the collected program counters, which can be
+// further processed using runtime.CallerFrames to obtain function details.
+func CallersLimit(skip, limit int) []uintptr {
+	switch {
+	case limit == 0:
+		return nil
+	case limit < 0:
+		return Callers(skip + 1)
+	}
+	pc := make([]uintptr, limit)
+	n := runtime.Callers(skip+2, pc)
+	return pc[:n]
+}

--- a/v2/callers_test.go
+++ b/v2/callers_test.go
@@ -25,3 +25,38 @@ func TestCallers(t *testing.T) {
 		}
 	}
 }
+
+func TestCallersLimit(t *testing.T) {
+	testCases := []struct {
+		name      string
+		skip      int
+		limit     int
+		expectLen int
+	}{
+		{name: "Skip 0, Limit 0", skip: 0, limit: 0, expectLen: 0},
+		{name: "Skip 0, Limit 1", skip: 0, limit: 1, expectLen: 1},
+		{name: "Skip 0, Limit 2", skip: 0, limit: 2, expectLen: 2},
+		{name: "Skip 1, Limit 1", skip: 1, limit: 1, expectLen: 1},
+		{name: "Skip 1, Limit 2", skip: 1, limit: 2, expectLen: 2},
+		{name: "Skip 2, Limit 1", skip: 2, limit: 1, expectLen: 1},
+		{name: "Skip 0, Limit 99", skip: 0, limit: 99, expectLen: -1},
+		{name: "Skip 1, Limit 99", skip: 1, limit: 99, expectLen: -1},
+		{name: "Skip 2, Limit 99", skip: 2, limit: 99, expectLen: -1},
+		{name: "Skip 0, Limit -1", skip: 0, limit: -1, expectLen: -1}, // Should return all frames after skip + 1
+		{name: "Skip 1, Limit -1", skip: 1, limit: -1, expectLen: -1}, // Should return all frames after skip + 1
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.expectLen == -1 {
+				pcs := make([]uintptr, 32)
+				n := runtime.Callers(tc.skip+1, pcs)
+				tc.expectLen = n
+			}
+			result := stacktrace.CallersLimit(tc.skip, tc.limit)
+			if len(result) != tc.expectLen {
+				t.Errorf("Expected length %d, got %d", tc.expectLen, len(result))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implements `CallersLimit` to return a limited number of stack frames. This function provides more control over the number of returned program counters, allowing
clients to avoid unnecessary allocations or processing.

Handles cases where `limit` is 0 (returns nil) or
negative (behaves like `Callers`). Includes new test cases to verify the functionality with different skip and limit values.

Closes #26 